### PR TITLE
Removed duplicated check_output command.

### DIFF
--- a/app/git.py
+++ b/app/git.py
@@ -25,7 +25,7 @@ class Git:
             try:
                 a = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode().strip()
                 print(a)
-                return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode().strip()
+                return a
             except subprocess.CalledProcessError as E:
                 print(f"Error: {E}")
                 return False


### PR DESCRIPTION
This fixes duplicate calls to `check_output` when the argument to `output` in `_execute_cmd` is set to True. This currently causes an error because it will attempt to recreate a tag twice, for example.