### PR TITLE
Added LFS install to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /setup
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+RUN apt -yqq update && apt -yqq install git-lfs
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM python:3.9.4
 
+RUN apt-get -yqq update \
+	&& apt-get -yqq install --no-install-recommends git-lfs \
+	&& apt-get clean \
+ 	&& rm -rf /var/lib/apt/lists/*
+
 WORKDIR /setup
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN apt -yqq update && apt -yqq install git-lfs
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR adds git-lfs to the Docker image. Without LFS, the push tag command will fail in LFS-enabled repositories.